### PR TITLE
Exposes more configuration options.

### DIFF
--- a/docs/_templates/tags.html
+++ b/docs/_templates/tags.html
@@ -1,0 +1,3 @@
+{% block tags %}
+    <a href="_tags/tagsindex.html">Tags overview</a>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
 
 tags_create_tags = True
 #tags_output_dir = "_tags"  # default
+tags_overview_title = "Site tags"  #default: "Tags overview"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -58,4 +59,9 @@ html_theme = 'pydata_sphinx_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']
+
+# html_sidebars = {
+#     "**": ["search-field.html", "sidebar-nav-bs.html", "sidebar-tags.html"],
+#     "_tags/*": ["search-field.html", "sidebar-nav-bs.html"],
+# }

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,3 +9,25 @@ A few custom configuration keys can be used in your ``conf.py`` file.
   - Default: ``True``
 - ``tags_output_dir``
   - Default: ``_tags``
+
+Tags overview page
+------------------
+
+You can customize the title of the tags overview page using the
+``tags_overview_title`` key in your ``conf.py`` file. For example,
+
+::
+
+  tags_overview_title = "Site tags"
+
+The default value for this configuration key is "Tags overview".
+
+This page should show you a list of available tags, next to a number describing
+how many pages are associated with each tag.
+
+Tags in the sidebar
+-------------------
+
+By default, ``sphinx-tags`` will generate a hidden ``toctree`` element for the
+"Tags overview" page. This means that if your theme uses a sidebar navigation
+element, your tags will appear there.

--- a/docs/devel.rst
+++ b/docs/devel.rst
@@ -1,0 +1,12 @@
+Development
+===========
+
+Tests
+-----
+
+Here are some tests.
+
+Release guide
+-------------
+
+TBA.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,21 +6,21 @@
 Welcome to sphinx-tags's documentation!
 =======================================
 
+sphinx-tags is a tiny Sphinx extension that implements blog-style tags for
+documentation.
+
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 3
+   :caption: Contents
 
    quickstart
    configuration
    examples
-   tests
-   release
+   devel
 
+.. toctree::
+   :caption: Site tags
+   :maxdepth: 2
+   :titlesonly:
 
-Indices and tables
-==================
-
-* :ref:`tagoverview`
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   _tags/tagsindex

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,4 +1,0 @@
-Release guide
-=============
-
-TBA

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -1,5 +1,0 @@
-Tests
-=====
-
-Here are some tests.
-


### PR DESCRIPTION
Enables configuration of the tags overview page title and creates an in-page toc for tags including listing the number of pages associated with each tag.

Closes #1
Closes #11