### PR TITLE
added alphabetic sorting and tag naming configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_tags/
 .DS_Store
 
 # PyBuilder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,8 @@ Version 0.1.6 (October 7, 2022)
 
 - Added page title and header as a parameter
 - Alphabetic sorting of tags
+
+Version 0.1.7 (October 8, 2022)
+
+- Added removal of all .md and .rst files in the tag folder before generating them again (avoids having duplicates after removing/changing some tag) 
+- Tag intro text as a parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@ Version 0.1 (August 23, 2022)
 
 - Includes support for MyST and sphinx-gallery
 
-Version 0.1.6 (October 7, 2022)
+Version 0.1.6 (October 9, 2022)
 
 - Added page title and header as a parameter
 - Alphabetic sorting of tags
-
-Version 0.1.7 (October 8, 2022)
-
-- Added removal of all .md and .rst files in the tag folder before generating them again (avoids having duplicates after removing/changing some tag) 
+- Added removal of all .md and .rst files in the tag folder before generating them again (avoids having duplicates after removing/changing some tag)
 - Tag intro text as a parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 Version 0.1 (August 23, 2022)
 
 - Includes support for MyST and sphinx-gallery
+
+Version 0.1.6 (October 7, 2022)
+
+- Added page title and header as a parameter
+- Alphabetic sorting of tags

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,8 @@ help:
 
 clean:
 	rm -rf _build/
-	rm -rf _tags
+
+# rm -rf _tags
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,10 @@ tags_create_tags = True
 # tags_output_dir = "_tags"  # default
 tags_overview_title = "All tags"  # default: "Tags overview"
 tags_extension = ["rst", "md"]  # default: ["rst"]
+tags_intro_text = "Tags in this page:"  # default: "Tags:"
+tags_page_title = "All my tags"  # default: "My tags:"
+tags_page_header = "Pages with this tag"  # default: "With this tag"
+tags_index_head = "Tags in this site"  # default: "Tags"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,6 +24,9 @@ A few custom configuration keys can be used in your ``conf.py`` file.
 - ``tags_index_head``
   - The string used as caption in the tagsindex file.
   Default: ``Tags``
+- ``tags_intro_text``
+  - The string used on pages that have tags.
+  Default: ``Tags``
 
 Tags overview page
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,6 +15,15 @@ A few custom configuration keys can be used in your ``conf.py`` file.
   Sphinx, and ``"md"`` if your are using MyST. Note that if you list both
   ``["md", "rst"]``, all generated pages to be created as Markdown files.
   Default: ``["rst"]``
+- ``tags_page_title``
+  - The title of the tag page, after which the tag is listed.
+  Default: ``Tag``
+- ``tags_page_header``
+  - The string after which the pages with the tag are listed.
+  Default: ``With this tag``
+- ``tags_index_head``
+  - The string used as caption in the tagsindex file.
+  Default: ``Tags``
 
 Tags overview page
 ------------------

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -7,7 +7,7 @@ from sphinx.util.docutils import SphinxDirective
 from docutils import nodes
 from pathlib import Path
 
-__version__ = "0.1.7"
+__version__ = "0.1.6"
 
 logger = getLogger("sphinx-tags")
 
@@ -28,12 +28,12 @@ class TagLinks(SphinxDirective):
 
     # Custom attributes
     separator = ","
-    
+
     def run(self):
         tags = [arg.replace(self.separator, "") for arg in self.arguments]
         result = nodes.paragraph()
-        result["classes"] = ["tags"]        
-        result += nodes.inline(text=self.env.app.config.tags_intro_text)
+        result["classes"] = ["tags"]
+        result += nodes.inline(text=f"{self.env.app.config.tags_intro_text} ")
         count = 0
 
         for tag in tags:
@@ -47,7 +47,7 @@ class TagLinks(SphinxDirective):
             #   |
             #    - current_doc_path
             docpath = Path(self.env.doc2path(self.env.docname)).parent
-         
+
             rootdir = os.path.relpath(
                 os.path.join(self.env.app.srcdir, self.env.app.config.tags_output_dir),
                 docpath,
@@ -68,7 +68,15 @@ class Tag:
         self.name = name
         self.items = []
 
-    def create_file(self, items, extension, tags_output_dir, srcdir, tags_page_title, tags_page_header):
+    def create_file(
+        self,
+        items,
+        extension,
+        tags_output_dir,
+        srcdir,
+        tags_page_title,
+        tags_page_header,
+    ):
         """Create file with list of documents associated with a given tag in
         toctree format.
 
@@ -184,7 +192,7 @@ def tagpage(tags, outdir, title, extension, tags_index_head):
         content.append(f"caption: {tags_index_head}")
         content.append("maxdepth: 1")
         content.append("---")
-        for tag in sorted(tags, key = lambda t: t.name):
+        for tag in sorted(tags, key=lambda t: t.name):
             content.append(f"{tag.name} ({len(tag.items)}) <{tag.name}>")
         content.append("```")
         content.append("")
@@ -203,7 +211,7 @@ def tagpage(tags, outdir, title, extension, tags_index_head):
         content.append(f"    :caption: {tags_index_head}")
         content.append("    :maxdepth: 1")
         content.append("")
-        for tag in sorted(tags, key = lambda t: t.name):
+        for tag in sorted(tags, key=lambda t: t.name):
             content.append(f"    {tag.name} ({len(tag.items)}) <{tag.name}.rst>")
         content.append("")
         filename = os.path.join(outdir, "tagsindex.rst")
@@ -235,9 +243,9 @@ def update_tags(app):
         if not os.path.exists(os.path.join(app.srcdir, tags_output_dir)):
             os.makedirs(os.path.join(app.srcdir, tags_output_dir))
 
-        for file in os.listdir(os.path.join(app.srcdir, tags_output_dir)):        
-            if file.endswith('md') or file.endswith('rst'):
-                os.remove(os.path.join(app.srcdir, tags_output_dir, file))                
+        for file in os.listdir(os.path.join(app.srcdir, tags_output_dir)):
+            if file.endswith("md") or file.endswith("rst"):
+                os.remove(os.path.join(app.srcdir, tags_output_dir, file))
 
         # Create pages for each tag
         tags, pages = assign_entries(app)
@@ -248,7 +256,7 @@ def update_tags(app):
                 tags_output_dir,
                 app.srcdir,
                 app.config.tags_page_title,
-                app.config.tags_page_header                
+                app.config.tags_page_header,
             )
         # Create tags overview page
         tagpage(
@@ -256,7 +264,7 @@ def update_tags(app):
             os.path.join(app.srcdir, tags_output_dir),
             app.config.tags_overview_title,
             app.config.tags_extension,
-            app.config.tags_index_head
+            app.config.tags_index_head,
         )
         logger.info("Tags updated", color="white")
     else:
@@ -275,11 +283,12 @@ def setup(app):
     app.add_config_value("tags_output_dir", "_tags", "html")
     app.add_config_value("tags_overview_title", "Tags overview", "html")
     app.add_config_value("tags_extension", ["rst"], "html")
-    app.add_config_value("tags_intro_text", "Tags: ", "html")
+    app.add_config_value("tags_intro_text", "Tags:", "html")
     app.add_config_value("tags_page_title", "My tags", "html")
     app.add_config_value("tags_page_header", "With this tag", "html")
     app.add_config_value("tags_index_head", "Tags", "html")
-        # internal config values
+
+    # internal config values
     app.add_config_value(
         "remove_from_toctrees",
         [
@@ -294,8 +303,6 @@ def setup(app):
     # this will not work?
     app.connect("builder-inited", update_tags)
     app.add_directive("tags", TagLinks)
-
-
 
     return {
         "version": __version__,


### PR DESCRIPTION
Hi there!

I am using Sphinx to create some documentation at work, and after searching for a tagging solution I found your fantastic extension! 

As I basically want to only use tags (or categories) as my index, I tried to make it easier to customize them. So now there are three additional settings in the `conf.py`:

- `tags_page_title`: this is the wording on top of a tag page, I call it "Category", the default is "Tag"
- `tags_page_header`: this is what appears before the tags, the default is "With this tag", in my case "In this category"
- `tags_index_head`: the title/header of the `toctree` in the tags index file that Sphinx generates.

On top of that I also added alphabetic sorting of the tags, both in the tag index and in each tag page. As for the latter, it is not perfect: as it goes by file name, if your article/post/paragraph is "_An interesting story_" but the actual file name is "_zorro_returns.md_", then of course it won't work as expected. A solution to this would require some RegEx, I suppose. 

I would assume that the alphabetic sorting should be the default behavior, but maybe it should be a flag instead? What do you think?

Anyway, I'm curious to find out what you think about this proposal! I went ahead and added it also to the documentation.

Thanks again for making this fantastic extension!
