### PR TITLE
Use Unix style path separator also on windows

### DIFF
--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -118,7 +118,7 @@ class Tag:
             #  items is a list of files associated with this tag
             for item in items:
                 # We want here the filepath relative to /docs/_tags
-                relpath = item.filepath.relative_to(srcdir)
+                relpath = item.filepath.relative_to(srcdir).as_posix()
                 content.append(f"../{relpath}")
             content.append("```")
         else:
@@ -134,7 +134,7 @@ class Tag:
             #  items is a list of files associated with this tag
             for item in sorted(items, key=lambda i: i.filepath):
                 # We want here the filepath relative to /docs/_tags
-                relpath = item.filepath.relative_to(srcdir)
+                relpath = item.filepath.relative_to(srcdir).as_posix()
                 content.append(f"    ../{relpath}")
 
         content.append("")


### PR DESCRIPTION
On Windows a backslash is used as path separator.
Sphinx cannot handle this.

Error Message: "WARNING: toctree contains reference to nonexisting document"

To avoid this use always unix style path separator