### PR TITLE
Add optional integration with sphinx-design badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,8 @@ Version 0.1.6 (October 9, 2022)
 - Alphabetic sorting of tags
 - Added removal of all .md and .rst files in the tag folder before generating them again (avoids having duplicates after removing/changing some tag)
 - Tag intro text as a parameter
+
+Version 0.2.0 (TBD)
+
+- Added optional integration with sphinx-design badges
+- Added support for symlinked sources

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 # -- Project information -----------------------------------------------------
 
 project = "sphinx-tags"
-copyright = "2022, melissawm"
+copyright = "2023, melissawm"
 author = "melissawm"
 
 # The full version, including alpha/beta/rc tags
@@ -39,6 +39,7 @@ extensions = [
 ]
 
 tags_create_tags = True
+tags_create_badges = True
 # tags_output_dir = "_tags"  # default
 tags_overview_title = "All tags"  # default: "Tags overview"
 tags_extension = ["rst", "md"]  # default: ["rst"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,6 +25,11 @@ A few custom configuration keys can be used in your ``conf.py`` file.
   ``With this tag``
 - ``tags_index_head``
   - The string used as caption in the tagsindex file. **Default:** ``Tags``
+- ``tags_create_badges``
+  - Whether to display tags using sphinx-design badges. **Default:** ``False``
+- ``tags_badge_colors``
+  - Colors to use for badges based on tag name. **Default:** ``{}``
+
 
 Tags overview page
 ------------------
@@ -47,3 +52,50 @@ Tags in the sidebar
 By default, ``sphinx-tags`` will generate a ``toctree`` element for the "Tags
 overview" page. This means that if your theme uses a sidebar navigation element,
 your tags will appear there.
+
+Tag badges
+----------
+If you also use the `sphinx-design <https://sphinx-design.readthedocs.io>`_ extension,
+you can optionally use its `badges <https://sphinx-design.readthedocs.io/en/latest/badges_buttons.html#badges>`_
+to display tags. To enable this, set ``tags_create_badges = True`` in ``conf.py``.
+
+Badge Colors
+~~~~~~~~~~~~
+
+You can also define which colors to use, based on the tag name. This can be defined
+in ``tags_badge_colors``, which should be a dict mapping tag names to colors.
+
+Color values may be one of:
+
+* ``None`` (plain badge): :bdg:`plain`
+* ``'primary'``: :bdg-primary:`primary`
+* ``'secondary'``: :bdg-secondary:`secondary`
+* ``'success'``: :bdg-success:`success`
+* ``'info'``: :bdg-info:`info`
+* ``'warning'``: :bdg-warning:`warning`
+* ``'danger'``: :bdg-danger:`danger`
+* ``'light'``: :bdg-light:`light`
+* ``'dark'``: :bdg-dark:`dark`
+
+Example::
+
+  tags_create_badges = True
+  tags_badge_colors = {
+      "tag1": "primary",
+      "tag2": "secondary",
+      "tag3": "success",
+  }
+
+Which will result in badges like this:
+:bdg-primary:`tag1` :bdg-secondary:`tag2` :bdg-success:`tag3`
+
+You may also use glob patterns to match multiple tags::
+
+  tags_badge_colors = {
+      "tag_*": "primary",
+      "status:*": "warning",
+      "*": "dark",  # Used as a default value
+  }
+
+This will result in badges like this:
+:bdg-primary:`tag_1` :bdg-primary:`tag_2` :bdg-warning:`status:done` :bdg-dark:`other`

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -1,7 +1,7 @@
-.. tags:: development
-
 Contribute
 ==========
+
+.. tags:: development
 
 All contributions are welcome in ``sphinx-tags``! All contributors and
 maintainers are expected to follow the `PSF Code of Conduct


### PR DESCRIPTION
Closes #9 

Here are some changes for adding support for [sphinx-design badges](https://sphinx-design.readthedocs.io/en/latest/badges_buttons.html#badges). Let me know what you think, or if you want to take a different approach.

Usage (settings in `conf.py`):
```python
tags_create_badges = True
```

Optional support for specifying badge colors by tag name or glob pattern:
```python
tags_badge_colors = {
    'coding': 'primary',
    'python': 'secondary',
    'prefix:*': 'warning',
    '*':  'light', 
}
```

Screenshot:
![image](https://user-images.githubusercontent.com/419936/204118827-ca808e79-7909-4d81-88b9-22eb3aa11460.png)
