### PR TITLE
Manually set Inliner state before creating tag links/badges

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -1,7 +1,7 @@
+.. tags:: development
+
 Contribute
 ==========
-
-.. tags:: development
 
 All contributions are welcome in ``sphinx-tags``! All contributors and
 maintainers are expected to follow the `PSF Code of Conduct

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -73,11 +73,9 @@ class TagLinks(SphinxDirective):
         """Get a sphinx-design reference badge for the given tag"""
         from sphinx_design.badges_buttons import XRefBadgeRole
 
-        # If the tag happens to be the first line of an rST document, then not all RSTState.Inliner
-        # attributes have been set yet, so we need to set them manually.
-        self.state.inliner.document = self.state.document
-        self.state.inliner.reporter = self.state.document.reporter
-        self.state.inliner.language = self.state.memo.language
+        # Required to set Inliner state, since we're directly creating a role object.
+        # Typically this would be done when parsing the role from document text.
+        text_nodes, messages = self.state.inline_text("", self.lineno)
 
         # Ref paths always use forward slashes, even on Windows
         tag_ref = f"{tag} <{relative_tag_dir.as_posix()}/{tag}>"

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -73,6 +73,12 @@ class TagLinks(SphinxDirective):
         """Get a sphinx-design reference badge for the given tag"""
         from sphinx_design.badges_buttons import XRefBadgeRole
 
+        # If the tag happens to be the first line of an rST document, then not all RSTState.Inliner
+        # attributes have been set yet, so we need to set them manually.
+        self.state.inliner.document = self.state.document
+        self.state.inliner.reporter = self.state.document.reporter
+        self.state.inliner.language = self.state.memo.language
+
         # Ref paths always use forward slashes, even on Windows
         tag_ref = f"{tag} <{relative_tag_dir.as_posix()}/{tag}>"
         tag_color = self._get_tag_color(tag)


### PR DESCRIPTION
Fixes #42

Here's what I found:
* The missing pieces of `Inliner` state are set in [docutils.parsers.rst.states.RSTState.inline_text()](https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/parsers/rst/states.py#l421) -> [Inliner.parse()](https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/parsers/rst/states.py#l614)
    * Includes `Inliner.document`, `reporter`, and `language` 
* So docutils is assuming that if any role is being processed, then `inline_text()` has already been called to parse the relevant text.
* In this case, the role is [XRefBadgeRole](https://github.com/executablebooks/sphinx-design/blob/main/sphinx_design/badges_buttons.py#L113) (used to create a badge with a link), but there is no corresponding text.
* Typically, that role would have been created by putting `{bdg}` or `{button-ref}` in a document and letting sphinx-design parse it. Instead, we've skipped that step and directly made a `XRefBadgeRole` object.
* As long as `tags` wasn't the first line of the document, `inline_text()` would have already been called by another role or directive's `run()` method.
* Somehow, the equivalent path in myst-parser doesn't have the same limitation.