### PR TITLE
Handle special characters in tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,10 @@
 ## Version 0.2.1 (June 28, 2023)
 
 - Added support for tagging Jupyter Notebooks using `nbsphinx` [gh-51](https://github.com/melissawm/sphinx-tags/pull/51)
+
+## Version 0.3.0
+
+- Fixed tag labels with spaces
+- Fixed tag labels with emoji
+- Added normalization for tag URLs to remove/replace urlencoded characters
+- Exclude files that match `exclude_patterns` from being tagged

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -5,5 +5,5 @@ Example of using a markdown file, with MyST.
 Because we don't (yet?) have a testing suite, the documentation will serve as
 tests for now.
 
-```{tags} mdexamples, tagdocumentation
+```{tags} md examples, tag documentation
 ```

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -5,5 +5,5 @@ Example of using a markdown file, with MyST.
 Because we don't (yet?) have a testing suite, the documentation will serve as
 tests for now.
 
-```{tags} md examples, tag documentation
+```{tags} md examples, tag documentation, {{🧪test tag; please ignore}}
 ```

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart
 
 The ``sphinx-tags`` package enables the use of blog-style tags with Sphinx.
 
-.. tags:: tagdocumentation, taginstallation
+.. tags:: tag documentation, tag installation
 
 Tags are created using the custom directive ``.. tags::`` with the tag titles
 as arguments.

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -155,6 +155,9 @@ class Tag:
 
 
         """
+        # Get sorted file paths for tag pages, relative to /docs/_tags
+        tag_page_paths = sorted(i.relpath(srcdir) for i in items)
+
         content = []
         if "md" in extension:
             filename = f"{self.file_basename}.md"
@@ -165,12 +168,8 @@ class Tag:
             content.append("maxdepth: 1")
             content.append(f"caption: {tags_page_header}")
             content.append("---")
-            #  items is a list of files associated with this tag
-            for item in items:
-                # We want here the filepath relative to /docs/_tags
-                # pathlib does not support relative paths for two absolute paths
-                relpath = Path(os.path.relpath(item.filepath, srcdir)).as_posix()
-                content.append(f"../{relpath}")
+            for path in tag_page_paths:
+                content.append(f"../{path}")
             content.append("```")
         else:
             filename = f"{self.file_basename}.rst"
@@ -183,12 +182,8 @@ class Tag:
             content.append("    :maxdepth: 1")
             content.append(f"    :caption: {tags_page_header}")
             content.append("")
-            #  items is a list of files associated with this tag
-            for item in sorted(items, key=lambda i: i.filepath):
-                # We want here the filepath relative to /docs/_tags
-                # pathlib does not support relative paths for two absolute paths
-                relpath = Path(os.path.relpath(item.filepath, srcdir)).as_posix()
-                content.append(f"    ../{relpath}")
+            for path in tag_page_paths:
+                content.append(f"    ../{path}")
 
         content.append("")
         with open(
@@ -229,6 +224,10 @@ class Entry:
             if tag not in tag_dict:
                 tag_dict[tag] = Tag(tag)
             tag_dict[tag].items.append(self)
+
+    def relpath(self, root_dir) -> str:
+        """Get this entry's path relative to the given root directory"""
+        return Path(os.path.relpath(self.filepath, root_dir)).as_posix()
 
 
 def _normalize_tag(tag: str) -> str:

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -13,7 +13,7 @@ from sphinx.util.logging import getLogger
 from sphinx.util.matching import get_matching_files
 from sphinx.util.rst import textwidth
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 logger = getLogger("sphinx-tags")
 

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -11,6 +11,7 @@ from typing import List
 from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.logging import getLogger
+from sphinx.util.rst import textwidth
 
 __version__ = "0.2.1"
 
@@ -173,8 +174,9 @@ class Tag:
             content.append("```")
         else:
             filename = f"{self.file_basename}.rst"
-            content.append(f"{tags_page_title}: {self.name}")
-            content.append("#" * (len(self.name) + len(tags_page_title) + 2))
+            header = f"{tags_page_title}: {self.name}"
+            content.append(header)
+            content.append("#" * textwidth(header))
             content.append("")
             #  Return link block at the start of the page"""
             content.append(".. toctree::")
@@ -271,7 +273,7 @@ def tagpage(tags, outdir, title, extension, tags_index_head):
         content.append(".. _tagoverview:")
         content.append("")
         content.append(title)
-        content.append("#" * len(title))
+        content.append("#" * textwidth(title))
         content.append("")
         # toctree for the page
         content.append(".. toctree::")

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -34,7 +34,10 @@ class TagLinks(SphinxDirective):
     separator = ","
 
     def run(self):
-        tags = [arg.replace(self.separator, "") for arg in self.arguments]
+        # Undo splitting args by whitespace, and use our own separator (to support tags with spaces)
+        tags = " ".join(self.arguments).split(self.separator)
+        tags = [t.strip() for t in tags]
+
         tag_dir = Path(self.env.app.srcdir) / self.env.app.config.tags_output_dir
         result = nodes.paragraph()
         result["classes"] = ["tags"]


### PR DESCRIPTION
Closes #39; closes #56; closes #58

## Changes
* Normalize output filenames (for nicer URLs without urlencoded characters)
* Allow spaces in tag labels
* Allow emoji in rST tag labels
    * After making tests, I found that rST header underlines were too short if any emoji (or other "wide" unicode characters) are in the tag label.
    * For reference: this can be handled with `unicodedata.east_asian_width()` (width category per character) or `sphinx.util.rst.textwidth()` (total width per string).
* Exclude source files that match `config.exclude_patterns`
* Sort tag list for MyST tag pages (currently only done for rST)

## Example
A tag named `{{🧪test tag; please ignore}}` will result in:
* `test-tag-please-ignore.md` / `.rst`
* `test-tag-please-ignore.html`
* Tag name is unchanged everywhere else (as displayed on tag index, tag pages, and pages with tags)

![Screenshot](https://github.com/melissawm/sphinx-tags/assets/419936/26e38db2-533d-4476-ad06-c144cd68fe32)