### PR TITLE
Automate releases based on git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+# When a new git tag is pushed:
+# * Build and publish a new release to PyPI
+# * Create new GitHub release with placeholder text linking to changelog
+name: Release
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Build package distributions
+        run: |
+          python -m pip install flit
+          flit build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        body: "See [changelog](https://github.com/melissawm/sphinx-tags/blob/main/CHANGELOG.md) for release details."

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -74,7 +74,10 @@ To cut a new release:
 
 1. Make sure the version string in ``src/sphinx_tags/__init__.py`` is updated
    with the release number you want.
-2. Run ``flit publish`` to upload your new version to PyPI.
-3. Run ``git tag <version>``, and ``git push origin --tags`` to update the tags
+2. Run ``git tag <version>``, and ``git push origin --tags`` to update the tags
    on GitHub.
-4. Make a new release using the GitHub interface.
+3. This will trigger a `GitHub Action <https://github.com/melissawm/sphinx-tags/actions>`__
+   that will build and publish the new release to PyPI. Verify that it completed
+   successfully.
+4. A new `GitHub release <https://github.com/melissawm/sphinx-tags/releases>`__
+   will be created automatically. Update the release description as needed.


### PR DESCRIPTION
Closes #72

# Changes
* Pushing a git tag triggers the workflow in `.github/workflows/release.yml`
* This builds the package wheel and sdist, and publishes them to PyPI using GitHub as a [trusted publisher](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/).
* It also creates a new GitHub release with placeholder text linking to the changelog. You can customize this and other settings [documented here](https://github.com/softprops/action-gh-release#-customizing).

# PyPI setup
To enable this on the PyPI end, you can go to **Manage -> Publishing -> Add a new publisher**. 
* **owner/repository:** melissawm/sphinx-tags
* **workflow name:** release.yml
* **environment name:** None

[More details in the PyPI docs here](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).

# Notes
* You can still publish releases manually if you need to. If you do that and then push a new tag, the action will just fail because a release with the specified version already exists. It shouldn't cause any problems.
* Feel free to ping me in the future if you have any problems with this, or want help updating this workflow to do something different.