### PR TITLE
Bump sphinx requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 
 dependencies = [
-    "sphinx>5",
+    "sphinx>5.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 
 dependencies = [
-    "sphinx>4",
+    "sphinx>5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 
 dependencies = [
-    "sphinx>5.1",
+    "sphinx>=5.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Sphinx<5 creates build errors, but we don't see them here (I think?) because we require sphinx>5 for tests/docs.