### PR TITLE
ENH Add reference label for rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -49,7 +49,9 @@ html output at the same position in the page as in the source .rst file.
 
 For each tag, a new rst file is created in ``<output_dir>/<tagname>.rst``
 containing a table of contents of each file associated with that tag (see
-:ref:`config`).
+:ref:`config`). A reference label will be added to this rst file, to enable you to
+cross-reference to it. The reference label will have the format: ``sphx_tag_<tagname>``
+e.g., a reference would look like: ``:ref:`sphx_tag_tag1```.
 
 A :ref:`tagoverview` page is also created that can be added to the index and
 show all tags defined for this documentation set.

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -178,6 +178,7 @@ class Tag:
             content.append("#" * textwidth(header))
             content.append("")
             #  Return link block at the start of the page"""
+            content.append(f".. _sphx_tag_{self.file_basename}_{self.name}:")
             content.append(".. toctree::")
             content.append("    :maxdepth: 1")
             content.append(f"    :caption: {tags_page_header}")

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -178,7 +178,7 @@ class Tag:
             content.append("#" * textwidth(header))
             content.append("")
             #  Return link block at the start of the page"""
-            content.append(f".. _sphx_tag_{self.file_basename}_{self.name}:")
+            content.append(f".. _sphx_tag_{self.file_basename}:")
             content.append(".. toctree::")
             content.append("    :maxdepth: 1")
             content.append(f"    :caption: {tags_page_header}")


### PR DESCRIPTION
closes #85

Adds reference label for .rst. AFAICT for md, you can just use the header to cross reference, so no special label needed.

I do not know how best to test this. Could I add a cross link to `test/sources/test-rst/index.rst` and then amend the test only for `testroot="rst"` ?