### PR TITLE
started of a domain

### DIFF
--- a/test/sources/test-ipynb/index.rst
+++ b/test/sources/test-ipynb/index.rst
@@ -11,4 +11,5 @@ Test document
 
 Test ref
 --------
-:ref:`sphx_tag_tag_1`
+`tag_1`
+.. :ref:`sphx_tag_tag_1`

--- a/test/sources/test-ipynb/page_1.ipynb
+++ b/test/sources/test-ipynb/page_1.ipynb
@@ -15,7 +15,7 @@
     "tags": []
    },
    "source": [
-    ".. tags:: tag_1, tag2, tag 3, [{(tag   4)}]"
+    ".. tag:tags:: tag_1, tag2, tag 3, [{(tag   4)}]"
    ]
   }
  ],

--- a/test/sources/test-ipynb/page_2.ipynb
+++ b/test/sources/test-ipynb/page_2.ipynb
@@ -15,7 +15,7 @@
     "tags": []
    },
    "source": [
-    ".. tags:: tag_1, tag_5, {{🧪test tag; please ignore🧪}}"
+    ".. tag:tags:: tag_1, tag_5, {{🧪test tag; please ignore🧪}}"
    ]
   }
  ],

--- a/test/sources/test-ipynb/page_5.ipynb
+++ b/test/sources/test-ipynb/page_5.ipynb
@@ -11,10 +11,10 @@
    "cell_type": "raw",
    "metadata": {
     "raw_mimetype": "text/restructuredtext",
-    "tags":[]
+    "tags": []
    },
    "source": [
-    ".. tags:: \n",
+    ".. tag:tags:: \n",
     "\n",
     "   tag_1, tag_5, \n",
     "   tag2, \n",

--- a/test/sources/test-ipynb/subdir/page_3.ipynb
+++ b/test/sources/test-ipynb/subdir/page_3.ipynb
@@ -15,7 +15,7 @@
     "tags": []
    },
    "source": [
-    ".. tags:: tag 3"
+    ".. tag:tags:: tag 3"
    ]
   }
  ],

--- a/test/sources/test-myst/index.md
+++ b/test/sources/test-myst/index.md
@@ -11,4 +11,4 @@ _tags/tagsindex
 ```
 
 ## Test ref
-{ref}`sphx_tag_tag_1`
+`tag_1`

--- a/test/sources/test-myst/page_1.md
+++ b/test/sources/test-myst/page_1.md
@@ -1,3 +1,3 @@
 # Page 1
-```{tags} tag_1, tag2, tag 3, [{(tag   4)}]
+```{tag:tags} tag_1, tag2, tag 3, [{(tag   4)}]
 ```

--- a/test/sources/test-myst/page_2.md
+++ b/test/sources/test-myst/page_2.md
@@ -1,3 +1,3 @@
 # Page 2
-```{tags} tag_1, tag_5, {{🧪test tag; please ignore🧪}}
+```{tag:tags} tag_1, tag_5, {{🧪test tag; please ignore🧪}}
 ```

--- a/test/sources/test-myst/page_5.md
+++ b/test/sources/test-myst/page_5.md
@@ -1,5 +1,5 @@
 # Page 5
-```{tags}
+```{tag:tags}
 tag_1, tag_5,
 tag2,
 tag 3, [{(tag   4)}]

--- a/test/sources/test-myst/subdir/page_3.md
+++ b/test/sources/test-myst/subdir/page_3.md
@@ -1,3 +1,3 @@
 # Page 3
-```{tags} tag 3
+```{tag:tags} tag 3
 ```

--- a/test/sources/test-rst/index.rst
+++ b/test/sources/test-rst/index.rst
@@ -13,4 +13,7 @@ Test document
 Test ref
 --------
 
-:ref:`sphx_tag_tag_1`
+`tag_1`
+
+
+.. :ref:`sphx_tag_tag_1`

--- a/test/sources/test-rst/page_1.rst
+++ b/test/sources/test-rst/page_1.rst
@@ -1,3 +1,3 @@
 Page 1
 ======
-.. tags:: tag_1, tag2, tag 3, [{(tag   4)}]
+.. tag:tags:: tag_1, tag2, tag 3, [{(tag   4)}]

--- a/test/sources/test-rst/page_2.rst
+++ b/test/sources/test-rst/page_2.rst
@@ -1,3 +1,3 @@
 Page 2
 ======
-.. tags:: tag_1, tag_5, {{🧪test tag; please ignore🧪}}
+.. tag:tags:: tag_1, tag_5, {{🧪test tag; please ignore🧪}}

--- a/test/sources/test-rst/page_5.rst
+++ b/test/sources/test-rst/page_5.rst
@@ -1,6 +1,6 @@
 Page 5
 ======
-.. tags::
+.. tag:tags::
 
    tag_1, tag_5,
    tag2,

--- a/test/sources/test-rst/subdir/page_3.rst
+++ b/test/sources/test-rst/subdir/page_3.rst
@@ -1,3 +1,3 @@
 Page 3
 ======
-.. tags:: tag 3
+.. tag:tags:: tag 3


### PR DESCRIPTION
So this is busted at the moment, but trying to shake out if it's worth it. Downside of domains is (if you don't use the `primary_domain` config) is that the tag becomes `tag:tags::` or the like. Upside is I think it makes stuff like #66 easier b/c it's another directive in the domain and has access to the same shared list. Also if I can get this working, then `tag_1` etc becomes the cross reference. 