### PR TITLE
Enable multiline tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ release = __version__
 extensions = ["sphinx_design", "sphinx_tags", "nbsphinx", "myst_parser"]
 
 tags_create_tags = True
-tags_create_badges = True
+tags_create_badges = False
 # tags_output_dir = "_tags"  # default
 tags_overview_title = "All tags"  # default: "Tags overview"
 tags_extension = ["rst", "md", "ipynb"]  # default: ["rst"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -106,18 +106,6 @@ Special characters
 Tags can contain spaces and special characters such as emoji. In that case, the
 tag will be normalized when processed. See our :doc:`examples/examples` for more details.
 
-Multiple lines of tags
-----------------------
-
-Tags can be passed in either as arguments or in the body of the directive:
-
-.. code-block:: rst
-
-   .. tags::
-
-      tag1, tag2, tag3,
-      tag4, tag5, tag6,
-
 Usage with sphinx-autobuild
 ---------------------------
 

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -5,3 +5,4 @@ Usage examples
 
     examples
     raw-cells
+    multiline

--- a/docs/examples/multiline.rst
+++ b/docs/examples/multiline.rst
@@ -1,0 +1,18 @@
+Multiline tags
+==============
+
+Since sphinx-tags 0.4.0, we now support multiline tag blocks. This means you can write
+
+.. code-block:: rst
+
+    .. tags::
+
+       several, different, tags, can be, added,
+       as long as, they are, separated
+
+to obtain
+
+.. tags::
+
+   several, different, tags, can be, added,
+   as long as, they are, separated


### PR DESCRIPTION
Hi folks, this is a ridiculously ugly temporary solution for the parsing of multiline tags while we work on #101 and #92 . I am pretty sure I have a way forward with a more "sphinxy" approach using the domain, but I won't have the time to finish this before SciPy. 

This PR adds a multiline parser for the tags in `Entry` - like I said it is ugly but seems to work on the simpler cases. If you agree with testing this as a temporary solution, we can cut a 0.3.2 and keep working on the domain approach for a 1.0 later.

cc @story645 