### PR TITLE
Make tagoverview markdown page orphan

### DIFF
--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -324,6 +324,10 @@ def tagpage(tags, outdir, title, extension, tags_index_head):
 
     if "md" in extension:
         content = []
+        content.append("---")
+        content.append("orphan: true")
+        content.append("---")
+        content.append("")
         content.append("(tagoverview)=")
         content.append("")
         content.append(f"# {title}")


### PR DESCRIPTION
I'm trying to use this extension in one of our project. It looks really nice. Thanks!

I got one issue though: When I don't include the `_tags/tagsindex.md` in a toctree, I get a warning.
If I try to include it, I get a recursion error...

I don't really want to include it in a toctree. I thought I could add an option to make it `orphan`.
When looking at the code I saw that the `tagoverview.rst` file is actually already `:orphan:`.

I just added the equivalent to the `.md` file to avoid warning when not including it in a toctree.