### PR TITLE
implement tag validation functionality and tests

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,37 +6,60 @@ Configuration
 A few custom configuration keys can be used in your ``conf.py`` file.
 
 - ``tags_create_tags``
-  - Whether to process tags or not. **Default:** ``False``
+
+  * Whether to process tags or not. **Default:** ``False``
+
 - ``tags_output_dir``
-  - Output directory for the tags source files, relative to the project root.
-  **Default:** ``_tags``
+
+  * Output directory for the tags source files, relative to the project root.
+    **Default:** ``_tags``
+
 - ``tags_extension``
-  - A list of file extensions to inspect. Use ``"rst"`` if you are using pure
-  Sphinx, and ``"md"`` if your are using MyST. Note that if you list both
-  ``["md", "rst"]``, all generated pages to be created as Markdown files.
-  **Default:** ``["rst"]``
+
+  * A list of file extensions to inspect. Use ``"rst"`` if you are using pure
+    Sphinx, and ``"md"`` if your are using MyST. Note that if you list both
+    ``["md", "rst"]``, all generated pages to be created as Markdown files.
+    **Default:** ``["rst"]``
+
 - ``tags_intro_text``
-  - The string used on pages that have tags. **Default:** ``Tags``
+
+  * The string used on pages that have tags. **Default:** ``Tags``
+
 - ``tags_page_title``
-  - The title of the tag page, after which the tag is listed. **Default:**
-  ``My tags``
+
+  * The title of the tag page, after which the tag is listed. **Default:**
+    ``My tags``
+
 - ``tags_page_header``
-  - The string after which the pages with the tag are listed. **Default:**
-  ``With this tag``
+
+  * The string after which the pages with the tag are listed. **Default:**
+    ``With this tag``
+
 - ``tags_index_head``
-  - The string used as caption in the tagsindex file. **Default:** ``Tags``
+
+  * The string used as caption in the tagsindex file. **Default:** ``Tags``
+
 - ``tags_create_badges``
-  - Whether to display tags using sphinx-design badges. **Default:** ``False``
+
+  * Whether to display tags using sphinx-design badges. **Default:** ``False``
+
 - ``tags_badge_colors``
-  - Colors to use for badges based on tag name. **Default:** ``{}``
+
+  * Colors to use for badges based on tag name. **Default:** ``{}``
+
 - ``tags_allowed_tag_names_regex``
-  - Define one or multiple regular expressions that each tag name must pass.
+
+  * Define one or multiple regular expressions that each tag name must pass.
     All names are allowed by default. **Default:** ``[]``
+
 - ``tags_minimum_tag_count``
-  - Define a required minimum amount of tags per directive.
+
+  * Define a required minimum amount of tags per directive.
     No minimum is set by default. **Default:** ``-1``
+
 - ``tags_maximum_tag_count``
-  - Define a required maximum amount of tags per directive.
+
+  * Define a required maximum amount of tags per directive.
     No minimum is set by default. **Default:** ``-1``
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,15 @@ A few custom configuration keys can be used in your ``conf.py`` file.
   - Whether to display tags using sphinx-design badges. **Default:** ``False``
 - ``tags_badge_colors``
   - Colors to use for badges based on tag name. **Default:** ``{}``
+- ``tags_allowed_tag_names_regex``
+  - Define one or multiple regular expressions that each tag name must pass.
+    All names are allowed by default. **Default:** ``[]``
+- ``tags_minimum_tag_count``
+  - Define a required minimum amount of tags per directive.
+    No minimum is set by default. **Default:** ``-1``
+- ``tags_maximum_tag_count``
+  - Define a required maximum amount of tags per directive.
+    No minimum is set by default. **Default:** ``-1``
 
 
 Tags overview page

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -73,6 +73,9 @@ class TagLinks(SphinxDirective):
         # (can happen after _normalize_tag())
         page_tags = list(filter(None, page_tags))
 
+        # validate if tags meet the requirements set by config
+        self.validate(page_tags)
+
         tag_dir = Path(self.env.app.srcdir) / self.env.app.config.tags_output_dir
         result = nodes.paragraph()
         result["classes"] = ["tags"]
@@ -109,7 +112,41 @@ class TagLinks(SphinxDirective):
 
         return [result]
 
-    def _get_plaintext_node(self, tag: str, file_basename: str) -> List[nodes.Node]:
+    def validate(self, page_tags):
+        """Validate each tag against the allowed tag names and tag count constraints."""
+
+        tags_allowed_tag_names_regex = self.env.app.config.tags_allowed_tag_names_regex
+        minimum_tag_count = self.env.app.config.tags_minimum_tag_count
+        maximum_tag_count = self.env.app.config.tags_maximum_tag_count
+
+        logger.verbose(
+            f"Validating tags {page_tags} with constraints: regex {tags_allowed_tag_names_regex}, min {minimum_tag_count}, max {maximum_tag_count}"
+        )
+        count = len(page_tags)
+
+        if minimum_tag_count >= 0 and count < minimum_tag_count:
+            raise ExtensionError(
+                f"Minimum tag count of {minimum_tag_count} not met for tags {page_tags} (count: {count})."
+            )
+
+        if 0 <= maximum_tag_count < count:
+            raise ExtensionError(
+                f"Maximum tag count of {maximum_tag_count} exceeded for tags {page_tags} (count: {count})."
+            )
+
+        if tags_allowed_tag_names_regex:
+            for tag in page_tags:
+                if not any(
+                    re.fullmatch(pattern, tag)
+                    for pattern in tags_allowed_tag_names_regex
+                ):
+                    raise ExtensionError(
+                        f"Tag '{tag}' is not in the list of allowed tag names."
+                    )
+
+    def _get_plaintext_node(
+        self, tag: str, file_basename: str, relative_tag_dir: Path
+    ) -> List[nodes.Node]:
         """Get a plaintext reference link for the given tag"""
         link = Path(self.env.app.config.tags_output_dir) / f"{file_basename}/"
         return nodes.reference(refuri="/" + str(link), text=tag)
@@ -435,6 +472,9 @@ def setup(app):
     app.add_config_value("tags_index_head", "Tags", "html")
     app.add_config_value("tags_create_badges", False, "html")
     app.add_config_value("tags_badge_colors", {}, "html")
+    app.add_config_value("tags_allowed_tag_names_regex", [], "html")
+    app.add_config_value("tags_minimum_tag_count", -1, "html")
+    app.add_config_value("tags_maximum_tag_count", -1, "html")
 
     # internal config values
     app.add_config_value(

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -144,9 +144,7 @@ class TagLinks(SphinxDirective):
                         f"Tag '{tag}' is not in the list of allowed tag names."
                     )
 
-    def _get_plaintext_node(
-        self, tag: str, file_basename: str, relative_tag_dir: Path
-    ) -> List[nodes.Node]:
+    def _get_plaintext_node(self, tag: str, file_basename: str) -> List[nodes.Node]:
         """Get a plaintext reference link for the given tag"""
         link = Path(self.env.app.config.tags_output_dir) / f"{file_basename}/"
         return nodes.reference(refuri="/" + str(link), text=tag)

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -75,6 +75,9 @@ class TagLinks(SphinxDirective):
         # (can happen after _normalize_tag())
         page_tags = list(filter(None, page_tags))
 
+        # validate if tags meet the requirements set by config
+        self.validate(page_tags)
+
         tag_dir = Path(self.env.app.srcdir) / self.env.app.config.tags_output_dir
         result = nodes.paragraph()
         result["classes"] = ["tags"]
@@ -110,6 +113,38 @@ class TagLinks(SphinxDirective):
         self.env.metadata[self.env.docname]["tags"] = page_tags
 
         return [result]
+
+    def validate(self, page_tags):
+        """Validate each tag against the allowed tag names and tag count constraints."""
+
+        tags_allowed_tag_names_regex = self.env.app.config.tags_allowed_tag_names_regex
+        minimum_tag_count = self.env.app.config.tags_minimum_tag_count
+        maximum_tag_count = self.env.app.config.tags_maximum_tag_count
+
+        logger.verbose(
+            f"Validating tags {page_tags} with constraints: regex {tags_allowed_tag_names_regex}, min {minimum_tag_count}, max {maximum_tag_count}"
+        )
+        count = len(page_tags)
+
+        if minimum_tag_count >= 0 and count < minimum_tag_count:
+            raise ExtensionError(
+                f"Minimum tag count of {minimum_tag_count} not met for tags {page_tags} (count: {count})."
+            )
+
+        if 0 <= maximum_tag_count < count:
+            raise ExtensionError(
+                f"Maximum tag count of {maximum_tag_count} exceeded for tags {page_tags} (count: {count})."
+            )
+
+        if tags_allowed_tag_names_regex:
+            for tag in page_tags:
+                if not any(
+                    re.fullmatch(pattern, tag)
+                    for pattern in tags_allowed_tag_names_regex
+                ):
+                    raise ExtensionError(
+                        f"Tag '{tag}' is not in the list of allowed tag names."
+                    )
 
     def _get_plaintext_node(
         self, tag: str, file_basename: str, relative_tag_dir: Path
@@ -444,6 +479,9 @@ def setup(app):
     app.add_config_value("tags_index_head", "Tags", "html")
     app.add_config_value("tags_create_badges", False, "html")
     app.add_config_value("tags_badge_colors", {}, "html")
+    app.add_config_value("tags_allowed_tag_names_regex", [], "html")
+    app.add_config_value("tags_minimum_tag_count", -1, "html")
+    app.add_config_value("tags_maximum_tag_count", -1, "html")
 
     # internal config values
     app.add_config_value(

--- a/test/sources/test-validations/conf.py
+++ b/test/sources/test-validations/conf.py
@@ -1,0 +1,6 @@
+extensions = ["sphinx_tags"]
+tags_create_tags = True
+tags_extension = ["rst"]
+tags_allowed_tag_names_regex = ["tag.*"]
+tags_minimum_tag_count = -1
+tags_maximum_tag_count = -1

--- a/test/sources/test-validations/index.rst
+++ b/test/sources/test-validations/index.rst
@@ -1,0 +1,5 @@
+Test Doc
+========
+Test document
+
+.. tags:: tag 1, tag 2, tag 3

--- a/test/test_badges.py
+++ b/test/test_badges.py
@@ -18,13 +18,13 @@ EXPECTED_CLASSES = {
 
 
 @pytest.mark.sphinx("html", testroot="badges")
-def test_build(app: SphinxTestApp, status: StringIO, warning: StringIO):
+def test_build(app: SphinxTestApp, status: StringIO):
     app.build()
     assert "build succeeded" in status.getvalue()
 
 
 @pytest.mark.sphinx("html", testroot="badges")
-def test_badges(app: SphinxTestApp, status: StringIO, warning: StringIO):
+def test_badges(app: SphinxTestApp, status: StringIO):
     """Parse output HTML for a page with badges, find badge links, and check for CSS classes for
     expected badge colors
     """

--- a/test/test_validation_tags.py
+++ b/test/test_validation_tags.py
@@ -42,6 +42,7 @@ def test_minimum_pass(app: SphinxTestApp, status: StringIO):
 @pytest.mark.sphinx(
     "html",
     testroot="validations",
+    freshenv=True,
     confoverrides={"tags_allowed_tag_names_regex": ["nottag.*"]},
 )
 def test_allowed_tag_names_regex_error(app: SphinxTestApp):
@@ -50,7 +51,10 @@ def test_allowed_tag_names_regex_error(app: SphinxTestApp):
 
 
 @pytest.mark.sphinx(
-    "html", testroot="validations", confoverrides={"tags_minimum_tag_count": 4}
+    "html",
+    testroot="validations",
+    freshenv=True,
+    confoverrides={"tags_minimum_tag_count": 4},
 )
 def test_minimum_error(app: SphinxTestApp):
     with pytest.raises(ExtensionError):
@@ -58,7 +62,10 @@ def test_minimum_error(app: SphinxTestApp):
 
 
 @pytest.mark.sphinx(
-    "html", testroot="validations", confoverrides={"tags_maximum_tag_count": 1}
+    "html",
+    testroot="validations",
+    freshenv=True,
+    confoverrides={"tags_maximum_tag_count": 1},
 )
 def test_maximum_error(app: SphinxTestApp):
     with pytest.raises(ExtensionError):

--- a/test/test_validation_tags.py
+++ b/test/test_validation_tags.py
@@ -1,0 +1,65 @@
+"""Tests for tag validation logic"""
+
+from io import StringIO
+import pytest
+from sphinx.errors import ExtensionError
+from sphinx.testing.util import SphinxTestApp
+from test.conftest import OUTPUT_ROOT_DIR
+import logging
+from sphinx_tags import TagLinks
+from unittest.mock import MagicMock
+
+OUTPUT_DIR = OUTPUT_ROOT_DIR / "general"
+
+"""Positive cases"""
+
+
+@pytest.mark.sphinx("html", testroot="validations")
+def test_default(app: SphinxTestApp, status: StringIO):
+    app.build(force_all=True)
+    assert "build succeeded" in status.getvalue()
+
+
+@pytest.mark.sphinx(
+    "html", testroot="validations", confoverrides={"tags_maximum_tag_count": 3}
+)
+def test_maximum_pass(app: SphinxTestApp, status: StringIO):
+    app.build(force_all=True)
+    assert "build succeeded" in status.getvalue()
+
+
+@pytest.mark.sphinx(
+    "html", testroot="validations", confoverrides={"tags_minimum_tag_count": 2}
+)
+def test_minimum_pass(app: SphinxTestApp, status: StringIO):
+    app.build(force_all=True)
+    assert "build succeeded" in status.getvalue()
+
+
+"""Negative cases"""
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="validations",
+    confoverrides={"tags_allowed_tag_names_regex": ["nottag.*"]},
+)
+def test_allowed_tag_names_regex_error(app: SphinxTestApp):
+    with pytest.raises(ExtensionError):
+        app.build(force_all=True)
+
+
+@pytest.mark.sphinx(
+    "html", testroot="validations", confoverrides={"tags_minimum_tag_count": 4}
+)
+def test_minimum_error(app: SphinxTestApp):
+    with pytest.raises(ExtensionError):
+        app.build(force_all=True)
+
+
+@pytest.mark.sphinx(
+    "html", testroot="validations", confoverrides={"tags_maximum_tag_count": 1}
+)
+def test_maximum_error(app: SphinxTestApp):
+    with pytest.raises(ExtensionError):
+        app.build(force_all=True)


### PR DESCRIPTION
## What?
In our project, a lot of people work on one shared documentation and we used a predefined set of tags that are allowed to be put on pages. For this, it would be nice to have a functionality that fails the build if tags outside of the predefined set of allowed tags are used.

## How?
implementation works so far, however the negative test cases only pass if they are run individually...
```
pytest test/test_validation_tags.py::test_allowed_tag_names_regex_error 
pytest test/test_validation_tags.py::test_minimum_error 
pytest test/test_validation_tags.py::test_maximum_error 
```
...but not when run with `pytest`.
```
FAILED test/test_validation_tags.py::test_allowed_tag_names_regex_error - Failed: DID NOT RAISE <class 'sphinx.errors.ExtensionError'>
FAILED test/test_validation_tags.py::test_minimum_error - Failed: DID NOT RAISE <class 'sphinx.errors.ExtensionError'>
FAILED test/test_validation_tags.py::test_maximum_error - Failed: DID NOT RAISE <class 'sphinx.errors.ExtensionError'>

```

behavior appears on python v3.12.9. JetBrains Rider 2024.3 pytest testrunner shows the same behavior.

I can't for the life of me figure out why that is (or how to adapt the negative cases to use either `status.getValue()` or the `TagLinks.validate()` method directly, similar to the `test_empty_taglinks` test in `test_general_tags`). Maybe one of you is smarter than me and knows what my mistake is. 😬 