### PR TITLE
Use root relative link and directory-style URL for plain text nodes

### DIFF
--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -111,9 +111,7 @@ class TagLinks(SphinxDirective):
 
         return [result]
 
-    def _get_plaintext_node(
-        self, tag: str, file_basename: str
-    ) -> List[nodes.Node]:
+    def _get_plaintext_node(self, tag: str, file_basename: str) -> List[nodes.Node]:
         """Get a plaintext reference link for the given tag"""
         link = Path(self.env.app.config.tags_output_dir) / f"{file_basename}/"
         return nodes.reference(refuri="/" + str(link), text=tag)

--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -112,11 +112,11 @@ class TagLinks(SphinxDirective):
         return [result]
 
     def _get_plaintext_node(
-        self, tag: str, file_basename: str, relative_tag_dir: Path
+        self, tag: str, file_basename: str
     ) -> List[nodes.Node]:
         """Get a plaintext reference link for the given tag"""
-        link = relative_tag_dir / f"{file_basename}.html"
-        return nodes.reference(refuri=str(link), text=tag)
+        link = Path(self.env.app.config.tags_output_dir) / f"{file_basename}/"
+        return nodes.reference(refuri="/" + str(link), text=tag)
 
     def _get_badge_node(
         self, tag: str, file_basename: str, relative_tag_dir: Path


### PR DESCRIPTION
- Use root relative link instead of directory-relative URL which caused tags to be appended to the on-page tags for plaintext nodes.
- Use directory-style URLs instead of appending .html to match the implementation for badges.

Current issue where links are not rendered correctly for plaintext nodes:
<img width="1854" height="1129" alt="sphinx-tags-appended-tags" src="https://github.com/user-attachments/assets/74cc53a8-17d0-4646-98de-b29d36d1efbe" />

Link to the parent tags page should be "<root>/_tags/how-to/" but it is currently generated wrongly as "<root>/how-to/_tags/how-to/" due to the relative path.

Hope this is enough info; lemme know if anything else is needed, thank you!