### PR TITLE
Revert "Use root relative link and directory-style URL for plain text…

### DIFF
--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -111,10 +111,12 @@ class TagLinks(SphinxDirective):
 
         return [result]
 
-    def _get_plaintext_node(self, tag: str, file_basename: str) -> List[nodes.Node]:
+    def _get_plaintext_node(
+        self, tag: str, file_basename: str, relative_tag_dir: Path
+    ) -> List[nodes.Node]:
         """Get a plaintext reference link for the given tag"""
-        link = Path(self.env.app.config.tags_output_dir) / f"{file_basename}/"
-        return nodes.reference(refuri="/" + str(link), text=tag)
+        link = relative_tag_dir / f"{file_basename}.html"
+        return nodes.reference(refuri=str(link), text=tag)
 
     def _get_badge_node(
         self, tag: str, file_basename: str, relative_tag_dir: Path


### PR DESCRIPTION
Reverts melissawm/sphinx-tags#118

CI failed on merge but not on PR: https://app.circleci.com/pipelines/github/melissawm/sphinx-tags

Test failures look real - and like they can be fixed by updating tests - and seems like the problem is that the tests aren't being run as part of the PR CI. 