### PR TITLE
Fix _get_plaintext_node function call parameters

### DIFF
--- a/src/sphinx_tags/__init__.py
+++ b/src/sphinx_tags/__init__.py
@@ -101,7 +101,7 @@ class TagLinks(SphinxDirective):
                 result += self._get_badge_node(tag, file_basename, relative_tag_dir)
                 tag_separator = " "
             else:
-                result += self._get_plaintext_node(tag, file_basename, relative_tag_dir)
+                result += self._get_plaintext_node(tag, file_basename)
                 tag_separator = f"{self.separator} "
             if not count == len(page_tags):
                 result += nodes.inline(text=tag_separator)


### PR DESCRIPTION
_get_plaintext_node was updated to require only 2 parameters so any use of this function needs to be fixed also.