### PR TITLE
Update RTD ubuntu image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
     python: "3"
 


### PR DESCRIPTION
The docs build is broken right now because of an outdated version of ubuntu in the RTD setup.